### PR TITLE
fix trailing slash problem in server url

### DIFF
--- a/kimai2-cmd.js
+++ b/kimai2-cmd.js
@@ -28,7 +28,7 @@ function callKimaiApi(httpMethod, kimaimethod, serversettings, qs = false, reqbo
     //console.log("calling kimai:", httpMethod, kimaimethod, serversettings)
     return new Promise((resolve, reject) => {
         const options = {
-            url: serversettings.kimaiurl + '/api/' + kimaimethod,
+            url: sanitizeServerUrl(serversettings.kimaiurl) + '/api/' + kimaimethod,
             headers: {
                 'X-AUTH-USER': serversettings.username,
                 'X-AUTH-TOKEN': serversettings.password,
@@ -395,6 +395,10 @@ function askForSettings() {
                 resolve(settings)
             });
     })
+}
+
+function sanitizeServerUrl(kimaiurl) {
+    return kimaiurl.replace(/\/+$/, "");
 }
 
 (function startup() {


### PR DESCRIPTION
When entering a URL like 
```
kimaiurl=http://127.0.0.1:8050/
```
this will lead to calls like this:
```
op:  {
  url: 'http://127.0.0.1:8050//api/timesheets/active',
  headers: { 'X-AUTH-USER': 'susan_super', 'X-AUTH-TOKEN': 'api_kitten' },
  method: 'GET'
}
```

Notice the double slash between host and path. Symfony doesn't accept such URLs and returns a 404. The PR will prevent/hide this simple human config mistake. So users can enter both URL versions with and without trailing slash.

As answer I received errors like:
```
? Select command List active measurements
undefined:1
<!DOCTYPE html>
^

SyntaxError: Unexpected token < in JSON at position 0
    at JSON.parse (<anonymous>)
    at Request._callback (/Users/kevin/Development/kimai2-cmd/kimai2-cmd.js:54:32)
    at Request.self.callback (/Users/kevin/Development/kimai2-cmd/node_modules/request/request.js:185:22)
    at Request.emit (events.js:196:13)
    at Request.<anonymous> (/Users/kevin/Development/kimai2-cmd/node_modules/request/request.js:1161:10)
    at Request.emit (events.js:196:13)
    at IncomingMessage.<anonymous> (/Users/kevin/Development/kimai2-cmd/node_modules/request/request.js:1083:12)
    at Object.onceWrapper (events.js:284:20)
    at IncomingMessage.emit (events.js:201:15)
    at endReadableNT (_stream_readable.js:1130:12)
```

At least in development mode, the API doesn't answer JSON friendly if there is a double slash in the URL. 

BTW: nice project!