### PR TITLE
Enable the Stop command to include a description of the measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Options:
 Commands:
   start [project] [activity]  start selected project and activity
   restart [id]                restart selected measurement
-  stop [id]                   stop all or selected measurement measurements, [id] is optional
+  stop [id] [description]     stop all or selected measurement measurements, [id] is optional, [description] is optional but needs [id]
   rainmeter                   update rainmeter skin
   list-active                 list active measurements
   list-recent                 list recent measurements

--- a/kimai2-cmd.js
+++ b/kimai2-cmd.js
@@ -184,12 +184,11 @@ function uiMainMenu(settings) {
                             selected.id = stopId;
 
                             // Only ask for the description if a specific measurement has been selected
-                            return selected.id ? uiEnterDescription () : undefined
+                            return selected.id ? uiEnterDescription() : undefined
                         })
                         .then(res => {
                             // only set the description if one has been prompted and entered
-                            if (res && res.enterDescription)
-                            {
+                            if (res && res.enterDescription) {
                                 return kimaiSetDescription(settings, selected.id, res.enterDescription)
                             }
                         })
@@ -307,7 +306,7 @@ function kimaiStart(settings, project, activity) {
 
         // select client or server time according to settings
         body.begin = kimaiServerTime(settings)
-        
+
         debug("kimaistart calling api: " + body)
 
         callKimaiApi('POST', 'timesheets', settings.serversettings, {
@@ -766,14 +765,13 @@ function uiAskForSettings() {
  * @param {string} id measurement id
  * @param {*} description the description that shall be applied to the measurement
  */
-function kimaiSetDescription(settings, id, description)
-{
+function kimaiSetDescription(settings, id, description) {
     return new Promise((resolve, reject) => {
 
         let body = {
             description: description
         }
-        
+
         debug("kimaiSetDescription calling api: " + body)
 
         callKimaiApi('PATCH', 'timesheets/' + id, settings.serversettings, {

--- a/kimai2-cmd.js
+++ b/kimai2-cmd.js
@@ -299,7 +299,7 @@ function kimaiStart(settings, project, activity) {
 
         let body = {
             project: project,
-            activity: activity,
+            activity: activity
         }
 
         // select client or server time according to settings

--- a/kimai2-cmd.js
+++ b/kimai2-cmd.js
@@ -950,11 +950,12 @@ program.command('restart [id]')
             })
     })
 
-program.command('stop [id]')
-    .description('stop all or selected measurement measurements, [id] is optional')
-    .action(function (measurementId) {
+program.command('stop [id] [description]')
+    .description('stop all or selected measurement measurements, [id] is optional, [description] is optional but needs [id]')
+    .action(function (measurementId, description) {
         checkSettings()
             .then(settings => {
+                kimaiSetDescription(settings, measurementId, description)
                 kimaiStop(settings, measurementId)
             })
     })

--- a/kimai2-cmd.js
+++ b/kimai2-cmd.js
@@ -762,7 +762,7 @@ function kimaiSetDescription(settings, id, description)
             description: description
         }
         
-        debug("kimaistart calling api: " + body)
+        debug("kimaiSetDescription calling api: " + body)
 
         callKimaiApi('PATCH', 'timesheets/' + id, settings.serversettings, {
                 reqbody: body

--- a/kimai2-cmd.js
+++ b/kimai2-cmd.js
@@ -182,9 +182,12 @@ function uiMainMenu(settings) {
                         })
                         .then(stopId => {
                             selected.id = stopId;
+
+                            // Only ask for the description if a specific measurement has been selected
                             return selected.id ? uiEnterDescription () : undefined
                         })
                         .then(res => {
+                            // only set the description if one has been prompted and entered
                             if (res && res.enterDescription)
                             {
                                 return kimaiSetDescription(settings, selected.id, res.enterDescription)
@@ -565,6 +568,9 @@ function uiSelectMeasurement(thelist) {
     })
 }
 
+/**
+ * Interactive UI: Prompt the user to enter a description for a measurement.
+ */
 function uiEnterDescription() {
     return new Promise((resolve, reject) => {
         inquirer
@@ -754,6 +760,12 @@ function uiAskForSettings() {
     })
 }
 
+/**
+ * Sets the 'description' field of a measurement. Works on both running and stopped measurements.
+ * @param {object} settings all settings read from the settings file
+ * @param {string} id measurement id
+ * @param {*} description the description that shall be applied to the measurement
+ */
 function kimaiSetDescription(settings, id, description)
 {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Hi! Thanks for making kima2-cmd!

This PR adds a new feature to kimai2-cmd, that allows the addition of a "description" when a (specific) measurement is stopped.

This fits nicely in our workflow: When employees stops a measurement, they can enter a description of the activities they accomplished in the last minutes/hours, which then shows up in the Kimai UI.

I hope you like this PR and it finds its way into kimai2-cmd. Of course I am open to any suggestions you might have to make this new featuer even better!

Cheers
Julian