### PR TITLE
Add interactive "start" when the project or activity are not mentioned

### DIFF
--- a/kimai2-cmd.js
+++ b/kimai2-cmd.js
@@ -943,7 +943,7 @@ program.command('start [project] [activity]')
         const selected = {}
         checkSettings()
             .then(settings => {
-                if (project && !activity) {
+                if (!project || !activity) {
                     uiKimaiStart(settings, project);
                     return;
                 }

--- a/kimai2-cmd.js
+++ b/kimai2-cmd.js
@@ -260,6 +260,7 @@ function kimaiServerTime(settings) {
  * Interactive ui: select a project and activity and starts it
  * 
  * @param {object} settings All settings read from ini
+ * @param {string} defaultProject The name of a project. If set, skips the project selection and goes directly to the activity selection.
  */
 function uiKimaiStart(settings, defaultProject) {
     return new Promise((resolve, reject) => {

--- a/kimai2-cmd.js
+++ b/kimai2-cmd.js
@@ -942,14 +942,36 @@ program.command('start [project] [activity]')
                 findId(settings, project, 'projects')
                     .then(projectid => {
                         selected.projectId = projectid
-                        return findId(settings, activity, 'activities')
+                        
+                        if (activity) {
+                            return findId(settings, activity, 'activities')
+                        } else {
+                            // The user did not provide the activity, ask it interactively.
+                            return readActivity(settings, projectid);
+                        }
                     })
-                    .then(activityid => {
+                    .then(activityid => {                        
                         selected.activityId = activityid
                         return kimaiStart(settings, selected.projectId, selected.activityId)
                     })
             })
     })
+
+function readActivity(settings, projectId) {
+    return new Promise((resolve, reject) => {
+        return kimaiList(settings, 'activities', false, {
+            filter: {
+                project: projectId
+            }
+        })
+        .then(res => {
+            return uiAutocompleteSelect(res[1], "Select activity")
+        })
+        .then(res => {
+            resolve(res.id);
+        })
+    });
+}
 
 program.command('restart [id]')
     .description('restart selected measurement')

--- a/kimai2-cmd.js
+++ b/kimai2-cmd.js
@@ -950,10 +950,10 @@ program.command('start [project] [activity]')
 
                 findId(settings, project, 'projects')
                     .then(projectid => {
-                        selected.projectId = projectid                        
+                        selected.projectId = projectid
                         return findId(settings, activity, 'activities')
                     })
-                    .then(activityid => {                        
+                    .then(activityid => {
                         selected.activityId = activityid
                         return kimaiStart(settings, selected.projectId, selected.activityId)
                     })

--- a/kimai2-innosetup.iss
+++ b/kimai2-innosetup.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{A10BF7B2-6641-4B06-9C68-268B649FCE57}
 AppName=kimai2-cmd
-AppVersion=1.3.1
+AppVersion=1.4.0
 AppPublisher=infeeeee
 AppPublisherURL=https://github.com/infeeeee/kimai2-cmd
 AppSupportURL=https://github.com/infeeeee/kimai2-cmd

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kimai2-cmd",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kimai2-cmd",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Command line client for Kimai2",
   "main": "kimai2-cmd.js",
   "bin": {


### PR DESCRIPTION
Greetings @infeeeee,

First, I find this CLI tool to be great and I would like to use it in my daily routine. However, to be personally more efficient I thought to start an activity faster directly from the CLI.

If the user knows the project and activity to start, they can use this:
```
$ kimai2-cmd start [project] [activity]
```

However, there are two different cases which are not currently covered by this command.

### Interactive selection of the activity

At work it is usually more convenient to select the activity from a list but to prefill the project, as such:
```
$ kimai2-cmd start [project]
```

Attempting to do this at the moment will result in an exception:

```
npm run start start "Sandbox"                                                                                                                      

> kimai2-cmd@1.3.1 start
> node kimai2-cmd.js "start" "Sandbox"

/home/elian/Projects/kimai2-cmd/kimai2-cmd.js:336
                   if (element.name.toLowerCase() == name.toLowerCase()) {
                                                          ^

TypeError: Cannot read properties of undefined (reading 'toLowerCase')
   at /home/elian/Projects/kimai2-cmd/kimai2-cmd.js:336:60
   at processTicksAndRejections (node:internal/process/task_queues:96:5)

Node.js v17.7.2
```

After this PR, the user is taken straight to the activity list (equivalent to `kimai2-cmd` -> "Start new measurement" -> select the project).

### Interactive selection of the project

If the user is extra lazy and simply wants to start an activity, but without knowing the project or the activity:

```
$ kimai2-cmd start [project]
```

At the moment, this results in an exception:

```
> kimai2-cmd@1.3.1 start
> node kimai2-cmd.js "start"

/home/elian/Projects/kimai2-cmd/kimai2-cmd.js:340
                    if (element.name.toLowerCase() == name.toLowerCase()) {
                                                           ^

TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at /home/elian/Projects/kimai2-cmd/kimai2-cmd.js:340:60
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

Node.js v17.7.2
```

After this PR, the user is simply sent to the normal UI workflow for starting an activity (select project, then select activity).

### Motivation

As mentioned previously, this can save the user for a few keystrokes. This is especially useful when the user does not have many projects or has a specific schedule. I want to use this at work to save a few keystrokes (since I usually have ~16 activities for an 8-hours workday).

If this modification does not fit your expectations for the classic CLI (especially since we are mixing the classic CLI with the interactive one), feel free to tell me. I have also tried to keep the modifications to the code as minimal as possible.
